### PR TITLE
Found a bug with this WritWorthy integration: crashes if New Life Charity Writ is in bank/bag

### DIFF
--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -373,6 +373,9 @@ RbI.enrichRuleBasedata = {
 	,["mmsoldcount"] = "item.mmSoldCount"
 	,["mmcraftcost"] = "item.mmCraftCost"
 	
+	,["wwmatcost"] = "item.wwMatCost"
+	,["wwmatcostpervoucher"] = "item.wwMatCostPerVoucher"
+
 	,["ttcvaluemin"] = "item.ttcValueMin"
 	,["ttcoffercount"] = "item.ttcOfferCount"
 	,["ttcitemcount"] = "item.ttcItemCount"

--- a/Modules/Item.lua
+++ b/Modules/Item.lua
@@ -114,6 +114,17 @@ function RbI.GetItemData(bagId, slotIndex)
 		item.mmSoldCount = mmStats.numItems or -1
 		item.mmCraftCost = mmStats.craftCost or -1
 		
+		-- WritWorthy Integration (initialize values even if ttc not loaded)
+		item.wwMatCost = -1
+		item.wwMatCostPerVoucher = -1
+		if (WritWorthy ~= nil) then
+			if 0 < (item.vouchers or 0) then
+				local matCost = WritWorthy.ToMatCost(itemLink)
+				item.wwMatCost = matCost
+				item.wwMatCostPerVoucher = matCost / item.vouchers
+			end
+		end
+
 		-- Tamriel Trade Center Integration (initialize values even if ttc not loaded)
 		local ttcStats
 		if(TamrielTradeCentrePrice ~= nil) then

--- a/Modules/Item.lua
+++ b/Modules/Item.lua
@@ -120,8 +120,10 @@ function RbI.GetItemData(bagId, slotIndex)
 		if (WritWorthy ~= nil) then
 			if 0 < (item.vouchers or 0) then
 				local matCost = WritWorthy.ToMatCost(itemLink)
-				item.wwMatCost = matCost
-				item.wwMatCostPerVoucher = matCost / item.vouchers
+				if matCost then
+					item.wwMatCost = matCost
+					item.wwMatCostPerVoucher = matCost / item.vouchers
+				end
 			end
 		end
 


### PR DESCRIPTION
Fixed.

(Yeah yeah sure I could just add support for New Life Charity Writs to WritWorthy, but that's not ever going to happen. No material cost estimate for New Life writs.)